### PR TITLE
推送版本标签时自动发布

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,13 @@ name: 构建桌面客户端
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
@@ -75,6 +77,7 @@ jobs:
         run: cargo test
 
       - name: 构建 Tauri 应用
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,3 +85,17 @@ jobs:
           args: ${{ matrix.args }}
           uploadWorkflowArtifacts: true
           workflowArtifactNamePattern: '[platform]-[arch]-[bundle]'
+
+      - name: 构建并发布 Tauri 应用
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: 酷安 ${{ github.ref_name }}
+          releaseBody: 请在下方下载适合当前系统的安装包。
+          releaseDraft: false
+          prerelease: false
+          generateReleaseNotes: true
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ npm run tauri build -- --bundles app,dmg
 - macOS Apple 芯片：磁盘映像 `.dmg`、应用包 `.app`
 - macOS Intel：磁盘映像 `.dmg`、应用包 `.app`
 
+## 自动发布
+
+推送以 `v` 开头的版本标签后，GitHub Actions 会自动构建全部平台，并创建公开的 GitHub Release，上传上述安装包。普通的 `main` 分支推送和 Pull Request 只执行构建检查，不会发布版本。
+
+发布前请先更新 `src-tauri/tauri.conf.json` 中的版本号，再创建并推送对应标签，例如：
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
 ## 常用检查
 
 ```bash


### PR DESCRIPTION
## 变更

- 推送 `v*` 标签时自动创建公开 GitHub Release
- 自动上传 Windows、Linux、macOS 各平台安装包
- 普通 `main` 推送和 Pull Request 保持只构建不发布
- README 增加中文发布说明

## 验证

- `npm run build`
- `cargo test`
- `npx --yes yaml-lint .github/workflows/build.yml`
- `git diff --check`